### PR TITLE
fix: prevent download being marked complete before verification finishes

### DIFF
--- a/lib/src/update.dart
+++ b/lib/src/update.dart
@@ -79,10 +79,19 @@ Future<void> _downloadChangedFiles({
         stagingDirectory: stagingDirectory,
         onProgress: (receivedBytes, _) {
           currentFileBytes = receivedBytes;
+
+          // Cap reported bytes to (totalBytes - 1) so that fraction never
+          // reaches 1.0 inside onProgress — fraction hits 1.0 only after
+          // downloadFile() returns, meaning disk flush + hash verification
+          // have completed successfully.
+          final rawReceived = completedBytes + currentFileBytes;
+          final cappedReceived =
+              totalBytes > 0 ? rawReceived.clamp(0, totalBytes - 1) : rawReceived;
+
           controller.add(
             UpdateProgress(
               totalBytes: totalBytes.toDouble(),
-              receivedBytes: (completedBytes + currentFileBytes).toDouble(),
+              receivedBytes: cappedReceived.toDouble(),
               currentFile: fileHash.filePath,
               totalFiles: files.length,
               completedFiles: completedFiles,
@@ -92,9 +101,12 @@ Future<void> _downloadChangedFiles({
         },
       );
 
+      // Increment counters BEFORE emitting the final progress event so that
+      // completedFiles is always accurate when fraction first reaches 1.0.
       completedFiles += 1;
       completedBytes +=
           fileHash.length > 0 ? fileHash.length : currentFileBytes;
+
       controller.add(
         UpdateProgress(
           totalBytes: totalBytes.toDouble(),

--- a/lib/updater_controller.dart
+++ b/lib/updater_controller.dart
@@ -136,6 +136,11 @@ class DesktopUpdaterController extends ChangeNotifier {
       manifestPath: _manifestPath,
     );
 
+    // Explicit flag — only set true when the stream completes without error.
+    // This prevents `_isDownloaded` from becoming true if the stream closes
+    // unexpectedly (e.g. the controller is closed before all files are done).
+    var downloadSucceeded = false;
+
     try {
       await for (final event in stream) {
         _updateProgress = event;
@@ -147,16 +152,20 @@ class DesktopUpdaterController extends ChangeNotifier {
         notifyListeners();
       }
 
-      _isDownloading = false;
-      _downloadProgress = 1.0;
-      _downloadedSize = _downloadSize;
-      _isDownloaded = true;
-      notifyListeners();
+      downloadSucceeded = true;
     } catch (_) {
       _isDownloading = false;
       _isDownloaded = false;
       notifyListeners();
       rethrow;
+    } finally {
+      if (downloadSucceeded) {
+        _isDownloading = false;
+        _downloadProgress = 1.0;
+        _downloadedSize = _downloadSize;
+        _isDownloaded = true;
+        notifyListeners();
+      }
     }
   }
 


### PR DESCRIPTION
- Cap reported receivedBytes to (totalBytes - 1) inside onProgress so that fraction never reaches 1.0 while the file is still being flushed to disk or awaiting hash verification.

- Increment completedFiles and completedBytes BEFORE emitting the final per-file UpdateProgress event so the counter is always accurate when fraction first reaches 1.0.

- Add explicit downloadSucceeded flag in downloadUpdate() so that _isDownloaded is only set to true when the stream closes normally (not from an unexpected early close or error path).